### PR TITLE
feat: Add more built-ins keywords

### DIFF
--- a/syntaxes/ohm.tmLanguage.json
+++ b/syntaxes/ohm.tmLanguage.json
@@ -177,7 +177,7 @@
     },
     "built-ins": {
       "name": "support.class",
-      "match": "\\b(?:any|alnum|end|digit|hexDigit|letter|space|spaces|lower|upper|unicodeLtmo)\\b"
+      "match": "\\b(?:any|alnum|end|digit|hexDigit|letter|space|spaces|lower|upper|unicodeLtmo|ListOf|listOf|NonemptyListOf|EmptyListOf|nonemptyListOf|emptyListOf)\\b"
     },
     "terminals": {
       "begin": "\"",


### PR DESCRIPTION
Ohm built in rules: https://github.com/harc/ohm/blob/master/ohm-js/src/built-in-rules.ohm